### PR TITLE
Expand assistant panel and drop transcription pane

### DIFF
--- a/index.html
+++ b/index.html
@@ -645,7 +645,7 @@
                 },
                 // Важный флаг, как в рабочей версии: включает дефолтный realtime-ввод
                 realtimeInputConfig: {},
-                inputAudioTranscription: { languageCodes: ['ru-RU'] }
+                inputAudioTranscription: { languageCode: 'ru-RU' }
               }
             };
             UI.log('WS->setup model:', { model: setupMsg.setup.model });


### PR DESCRIPTION
## Summary
- Remove "You said" panel to give more space to assistant responses
- Adjust grid layout so the assistant panel spans the full width
- Clean up UI logic by dropping unused transcription handling
- Force Russian transcription language and remove user selector
- Show newest Gemini responses at the top of the assistant panel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cd78b8cc83249720391bca336082