### PR TITLE
feat: buffer assistant replies until completion

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,6 +243,7 @@
         block.textContent = text;
         el.prepend(block);
         el.scrollTop = 0;
+        return block;
       },
       setText(el, text) {
         el.textContent = text;
@@ -294,8 +295,11 @@
         Utils.prependBlock(assistantOut, text);
       }
       function setAssistant(text) { Utils.setText(assistantOut, text); }
+      function prependAssistantBlock(text) {
+        return Utils.prependBlock(assistantOut, text);
+      }
 
-      return { setWS, setMic, setModel, clearLog, log, appendAssistant, setAssistant };
+      return { setWS, setMic, setModel, clearLog, log, appendAssistant, setAssistant, prependAssistantBlock };
     })();
 
     // --------------------------------------------------------
@@ -597,6 +601,8 @@
       let mic = null;
       let setupDone = false;
       let currentModel = modelEl.value;
+      let pendingReply = '';
+      let pendingEl = null;
 
       function setButtonsConnected(connected) {
         connectBtn.disabled = connected;
@@ -750,17 +756,25 @@
           const parts = msg.serverContent.modelTurn.parts;
           for (const p of parts) {
             if (typeof p.text === 'string' && p.text.length) {
-              UI.appendAssistant(p.text);
+              pendingReply += p.text;
+              if (!pendingEl) {
+                pendingEl = UI.prependAssistantBlock('');
+              }
+              Utils.setText(pendingEl, pendingReply);
             }
           }
           return;
         }
         if (msg.generationComplete) {
           UI.log('WS<-(generationComplete)');
+          if (pendingEl) { pendingEl.remove(); pendingEl = null; }
+          if (pendingReply) { UI.appendAssistant(pendingReply); pendingReply = ''; }
           return;
         }
         if (msg.turnComplete) {
           UI.log('WS<-(turnComplete)');
+          if (pendingEl) { pendingEl.remove(); pendingEl = null; }
+          if (pendingReply) { UI.appendAssistant(pendingReply); pendingReply = ''; }
           return;
         }
         // На всякий — выведем сырой кадр

--- a/index.html
+++ b/index.html
@@ -131,6 +131,11 @@
       flex-direction: column;
       gap: 8px;
     }
+    #assistantOut .pending {
+      border-left: 2px solid var(--accent);
+      padding-left: 6px;
+      opacity: 0.8;
+    }
     .chat-input {
       display: grid;
       grid-template-columns: 1fr auto;
@@ -759,6 +764,7 @@
               pendingReply += p.text;
               if (!pendingEl) {
                 pendingEl = UI.prependAssistantBlock('');
+                pendingEl.classList.add('pending');
               }
               Utils.setText(pendingEl, pendingReply);
             }
@@ -768,13 +774,13 @@
         if (msg.generationComplete) {
           UI.log('WS<-(generationComplete)');
           if (pendingEl) { pendingEl.remove(); pendingEl = null; }
-          if (pendingReply) { UI.appendAssistant(pendingReply); pendingReply = ''; }
+          if (pendingReply) { UI.prependAssistantBlock(pendingReply); pendingReply = ''; }
           return;
         }
         if (msg.turnComplete) {
           UI.log('WS<-(turnComplete)');
           if (pendingEl) { pendingEl.remove(); pendingEl = null; }
-          if (pendingReply) { UI.appendAssistant(pendingReply); pendingReply = ''; }
+          if (pendingReply) { UI.prependAssistantBlock(pendingReply); pendingReply = ''; }
           return;
         }
         // На всякий — выведем сырой кадр

--- a/index.html
+++ b/index.html
@@ -131,9 +131,14 @@
       flex-direction: column;
       gap: 8px;
     }
+    #assistantOut > div {
+      background: rgba(255,255,255,0.03);
+      padding: 4px 6px;
+      border-left: 2px solid var(--border);
+      border-radius: 6px;
+    }
     #assistantOut .pending {
-      border-left: 2px solid var(--accent);
-      padding-left: 6px;
+      border-left-color: var(--accent);
       opacity: 0.8;
     }
     .chat-input {
@@ -609,6 +614,20 @@
       let pendingReply = '';
       let pendingEl = null;
 
+      function finalizePending() {
+        if (pendingEl) {
+          if (pendingReply) {
+            pendingEl.classList.remove('pending');
+          } else {
+            pendingEl.remove();
+          }
+          pendingEl = null;
+        } else if (pendingReply) {
+          UI.prependAssistantBlock(pendingReply);
+        }
+        pendingReply = '';
+      }
+
       function setButtonsConnected(connected) {
         connectBtn.disabled = connected;
         disconnectBtn.disabled = !connected;
@@ -773,14 +792,12 @@
         }
         if (msg.generationComplete) {
           UI.log('WS<-(generationComplete)');
-          if (pendingEl) { pendingEl.remove(); pendingEl = null; }
-          if (pendingReply) { UI.prependAssistantBlock(pendingReply); pendingReply = ''; }
+          finalizePending();
           return;
         }
         if (msg.turnComplete) {
           UI.log('WS<-(turnComplete)');
-          if (pendingEl) { pendingEl.remove(); pendingEl = null; }
-          if (pendingReply) { UI.prependAssistantBlock(pendingReply); pendingReply = ''; }
+          finalizePending();
           return;
         }
         // На всякий — выведем сырой кадр

--- a/index.html
+++ b/index.html
@@ -616,16 +616,13 @@
 
       function finalizePending() {
         if (pendingEl) {
-          if (pendingReply) {
-            pendingEl.classList.remove('pending');
-          } else {
-            pendingEl.remove();
-          }
+          pendingEl.remove();
           pendingEl = null;
-        } else if (pendingReply) {
-          UI.prependAssistantBlock(pendingReply);
         }
-        pendingReply = '';
+        if (pendingReply) {
+          UI.appendAssistant(pendingReply);
+          pendingReply = '';
+        }
       }
 
       function setButtonsConnected(connected) {
@@ -777,6 +774,9 @@
           return;
         }
         if (msg.serverContent?.modelTurn?.parts) {
+          if (pendingReply || pendingEl) {
+            finalizePending();
+          }
           const parts = msg.serverContent.modelTurn.parts;
           for (const p of parts) {
             if (typeof p.text === 'string' && p.text.length) {


### PR DESCRIPTION
## Summary
- accumulate streaming text in `pendingReply` and display it in a temporary block until generation ends
- finalize assistant messages on `generationComplete` or `turnComplete`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ca2348d0832494eddd584eaed4a3